### PR TITLE
Keep track of number of packages received by namespace

### DIFF
--- a/src/samplers/statsd.h
+++ b/src/samplers/statsd.h
@@ -30,6 +30,7 @@ struct brubeck_statsd_secure {
 	pthread_t thread;
 };
 
+void stats_track_by_namespace(struct brubeck_server *server, const char *msg_key, size_t msg_key_len);
 void brubeck_statsd_packet_parse(struct brubeck_server *server, char *buffer, char *end);
 int brubeck_statsd_msg_parse(struct brubeck_statsd_msg *msg, char *buffer, char *end);
 

--- a/tests/helpers.h
+++ b/tests/helpers.h
@@ -1,0 +1,20 @@
+#ifndef __HELPERS_H__
+#define __HELPERS_H__
+
+#include "sput.h"
+#include "brubeck.h"
+
+static struct brubeck_server *
+new_server()
+{
+	struct brubeck_server *server = malloc(sizeof(struct brubeck_server));
+	memset(server, 0x0, sizeof(struct brubeck_server));
+	brubeck_slab_init(&server->slab);
+
+	server->metrics = brubeck_hashtable_new(1 << 20);
+	server->backends[0] = malloc(sizeof(struct brubeck_backend));
+
+	return server;
+}
+
+#endif

--- a/tests/main.c
+++ b/tests/main.c
@@ -19,6 +19,8 @@ void test_get_metric_suffix(void);
 void test_brubeck_metric_find(void);
 void test_brubeck_metric_find_adds_key_suffix(void);
 
+void test_stats_track_by_namespace(void);
+
 int main(int argc, char *argv[])
 {
 	sput_start_testing();
@@ -42,6 +44,9 @@ int main(int argc, char *argv[])
 
 	sput_enter_suite("statsd: packet parsing");
 	sput_run_test(test_statsd_msg__parse_strings);
+
+	sput_enter_suite("statsd");
+	sput_run_test(test_stats_track_by_namespace);
 
 	sput_enter_suite("metric: creating / sampling metrics");
 	sput_run_test(test_get_metric_suffix);

--- a/tests/metric.c
+++ b/tests/metric.c
@@ -1,5 +1,6 @@
 #include "sput.h"
 #include "brubeck.h"
+#include "helpers.h"
 
 void test_get_metric_suffix(void)
 {
@@ -16,19 +17,6 @@ void test_get_metric_suffix(void)
 
 	sput_fail_unless(get_metric_suffix(23),
 					 ".unknown");
-}
-
-static struct brubeck_server *
-new_server()
-{
-	struct brubeck_server *server = malloc(sizeof(struct brubeck_server));
-	memset(server, 0x0, sizeof(struct brubeck_server));
-	brubeck_slab_init(&server->slab);
-
-	server->metrics = brubeck_hashtable_new(1 << 20);
-	server->backends[0] = malloc(sizeof(struct brubeck_backend));
-
-	return server;
 }
 
 void test_brubeck_metric_find(void)

--- a/tests/statsd.c
+++ b/tests/statsd.c
@@ -1,0 +1,20 @@
+#include "sput.h"
+#include "brubeck.h"
+#include "helpers.h"
+
+void test_stats_track_by_namespace(void)
+{
+	struct brubeck_metric *metric = NULL;
+	struct brubeck_server *server = new_server();
+
+	stats_track_by_namespace(server, "core.has.a.counter", 18);
+	stats_track_by_namespace(server, "core.has.a.counter", 18);
+	stats_track_by_namespace(server, "core.has.a.counter", 18);
+	stats_track_by_namespace(server, "web.has.a.gauge", 15);
+
+	metric = brubeck_metric_find(server, "statsd.team.core", 17, BRUBECK_MT_METER);
+	sput_fail_unless(metric->as.meter.value == 3.0, "metrics match");
+
+	metric = brubeck_metric_find(server, "statsd.team.web", 16, BRUBECK_MT_METER);
+	sput_fail_unless(metric->as.meter.value == 1.0, "metrics match");
+}


### PR DESCRIPTION
This takes the first part of the metric key and counts them in a
separate metric.